### PR TITLE
Fix glob pattern matching on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,7 +90,7 @@ class ColorDecorationProvider implements vscode.FileDecorationProvider {
           
           if (hasGlob) {
             // For glob patterns, match against the relative path from workspace root
-            const relativePath = path.relative(root, uri.fsPath).replace(/\\/g, '/');
+            const relativePath = path.relative(root, uri.path).replace(/\\/g, '/');
             return minimatch(relativePath, folder.path, { matchBase: true });
           }
           


### PR DESCRIPTION
## Problem

Glob patterns don't work on Windows. For example:

```json
"folder-path-color.folders": [
    { "path": "src/*", "color": "blue" },
    { "path": "**/test", "color": "red" }
]
```

## Expected Behavior

Glob patterns like `src/*` or `**/test` should match folders on all platforms.

## Actual Behavior

On Windows, glob patterns never match. Only exact paths (e.g., `"path": "src/MyProject"`) work, because they use the `.includes()` fallback.

## Root Cause

The relative path is computed using:
```typescript
const relativePath = path.relative(root, uri.fsPath).replace(/\\/g, '/');
```
- `root` is a URI path (e.g., `/C:/Users/...`)
- `uri.fsPath` is a native Windows path (e.g., `C:\Users\...`)

`path.relative()` between these two different formats produces an incorrect result on Windows, so `minimatch` never matches.

## Fix
Use `uri.path` instead of `uri.fsPath`, so both paths are in the same URI format.